### PR TITLE
Fix compilation with the latest esp-idf and components

### DIFF
--- a/components/tinyusb/additions/include_private/descriptors_control.h
+++ b/components/tinyusb/additions/include_private/descriptors_control.h
@@ -61,7 +61,6 @@ enum {
                        CFG_TUD_HID * TUD_HID_DESC_LEN
 };
 
-bool tusb_desc_set;
 void tusb_set_descriptor(tusb_desc_device_t *desc, const char **str_desc);
 void tusb_set_config_descriptor(const uint8_t *config_desc);
 tusb_desc_device_t *tusb_get_active_desc(void);

--- a/components/tinyusb/additions/src/descriptors_control.c
+++ b/components/tinyusb/additions/src/descriptors_control.c
@@ -235,7 +235,6 @@ void tusb_set_descriptor(tusb_desc_device_t *dev_desc, const char **str_desc)
         memcpy(s_str_descriptor, str_desc,
                sizeof(s_str_descriptor[0])*USB_STRING_DESCRIPTOR_ARRAY_SIZE);
     }
-    tusb_desc_set = true;
 }
 
 void tusb_set_config_descriptor(const uint8_t *config_desc)
@@ -271,5 +270,4 @@ void tusb_clear_descriptor(void)
     memset(&s_str_descriptor, 0, sizeof(s_str_descriptor));
     free(s_config_descriptor);
     s_config_descriptor = NULL;
-    tusb_desc_set = false;
 }

--- a/components/tinyusb/additions/src/tinyusb.c
+++ b/components/tinyusb/additions/src/tinyusb.c
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "sdkconfig.h"
+#include "rom/gpio.h"
 #include "driver/gpio.h"
 #include "driver/periph_ctrl.h"
 #include "esp_log.h"

--- a/main/keyboard_pm.c
+++ b/main/keyboard_pm.c
@@ -87,7 +87,7 @@ static volatile uint last_pm_timestamp = 0;
 static SemaphoreHandle_t pm_lock;
 
 // charging pin event queue
-static xQueueHandle gpio_evt_queue = NULL;
+static QueueHandle_t gpio_evt_queue = NULL;
 
 static const char *TAG = "kb-pm";
 

--- a/main/pin_cfg.h
+++ b/main/pin_cfg.h
@@ -116,7 +116,7 @@
 
 #define GPIO_INIT_IN_FLOATING(pinnum) \
   do { \
-    gpio_pad_select_gpio(pinnum); \
+    gpio_reset_pin(pinnum); \
     gpio_set_direction(pinnum, GPIO_MODE_INPUT); \
     gpio_pullup_dis(pinnum); \
     gpio_pulldown_dis(pinnum); \
@@ -124,7 +124,7 @@
 
 #define GPIO_INIT_IN_PULLUP(pinnum) \
   do { \
-    gpio_pad_select_gpio(pinnum); \
+    gpio_reset_pin(pinnum); \
     gpio_set_direction(pinnum, GPIO_MODE_INPUT); \
     gpio_pullup_en(pinnum); \
     gpio_pulldown_dis(pinnum); \
@@ -132,7 +132,7 @@
 
 #define GPIO_INIT_IN_PULLDOWN(pinnum) \
   do { \
-    gpio_pad_select_gpio(pinnum); \
+    gpio_reset_pin(pinnum); \
     gpio_set_direction(pinnum, GPIO_MODE_INPUT); \
     gpio_pullup_dis(pinnum); \
     gpio_pulldown_en(pinnum); \
@@ -152,14 +152,14 @@
 
 #define GPIO_INIT_OUT_PULLUP(pinnum) \
   do { \
-    gpio_pad_select_gpio(pinnum); \
+    gpio_reset_pin(pinnum); \
     gpio_set_direction(pinnum, GPIO_MODE_OUTPUT); \
     gpio_pullup_en(pinnum); \
   } while(0)
 
 #define GPIO_INIT_OUT_PULLDOWN(pinnum) \
   do { \
-    gpio_pad_select_gpio(pinnum); \
+    gpio_reset_pin(pinnum); \
     gpio_set_direction(pinnum, GPIO_MODE_OUTPUT); \
     gpio_pulldown_en(pinnum); \
   } while(0)


### PR DESCRIPTION
- Replace `gpio_pad_select_gpio` with `gpio_reset_pin`, refering to
  https://www.esp32.com/viewtopic.php?t=25505
- `xQueueHandle` is no longer defined if
   `CONFIG_FREERTOS_ENABLE_BACKWARD_COMPATIBILITY` is not set
- Remove variable `tusb_desc_set` which prevents compilation and is never used
- Include `rom/gpio.h` for macro `GPIO_FUNC_IN_LOW` and `GPIO_FUNC_IN_HIGH`